### PR TITLE
Remove win32_product as it can be dangerous

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ New-Object System.Management.Automation.PSCredential($UserName,$Password)
 ## How to find installed applications on a windows machine
 
 ```PowerShell
-Get-WmiObject -Class Win32_Product | Format-wide -column 1
+Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* |  Select-Object DisplayName, DisplayVersion, Publisher, InstallDate
 ```
 
 <hr>


### PR DESCRIPTION
As detailed in [this blog post](https://blogs.technet.microsoft.com/heyscriptingguy/2013/11/15/use-powershell-to-find-installed-software/)  and [this blog post](https://blogs.technet.microsoft.com/heyscriptingguy/2011/11/13/use-powershell-to-quickly-find-installed-software/) it is best to avoid win32_product as it causes a consistency check on all installed products.

Searching the registry is a lot faster and can return some other useful information information such as the UninstallString.